### PR TITLE
fix link to aur pkgbuild in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ in `/etc/udev/rules.d` and `aclidswitch` in `/usr/bin`.
 
 ## Arch Linux
 Arch Linux users can also install the package from the AUR 
-[here](https://aur.archlinux.org/packages/aclidswitch/).
+[here](https://aur.archlinux.org/packages/aclidswitch-git/).


### PR DESCRIPTION
Hey - thanks for the great little utility!

The link to your PKGBUILD is off. Here's the fix.
